### PR TITLE
Conectar pedido y productos al backend

### DIFF
--- a/src/app/pedido/[id]/share/page.tsx
+++ b/src/app/pedido/[id]/share/page.tsx
@@ -14,6 +14,7 @@ type OrderSummary = {
     grandTotal: number;
   };
   items: Item[];
+  whatsapp?: { number: string; waLink: string } | null;
 };
 
 const money = (n: number) => new Intl.NumberFormat("es-CO").format(n);
@@ -77,6 +78,15 @@ export default function PedidoShare({ params }: { params: Promise<{ id: string }
       ) : (
         <>
           <div className="mt-4 flex flex-wrap gap-3">
+            {resumen.whatsapp?.waLink && (
+              <a
+                href={resumen.whatsapp.waLink}
+                target="_blank"
+                className="h-10 rounded-lg px-4 border border-white/15 hover:border-white/30 inline-flex items-center"
+              >
+                WhatsApp
+              </a>
+            )}
             <button onClick={compartir} className="h-10 rounded-lg px-4 border border-white/15 hover:border-white/30">
               Compartir…
             </button>

--- a/src/app/producto/[slug]/page.tsx
+++ b/src/app/producto/[slug]/page.tsx
@@ -1,6 +1,5 @@
-import Image from "next/image";
 import { notFound } from "next/navigation";
-import AddToCart from "@/components/product/AddToCart";
+import ProductDetail from "@/components/product/ProductDetail";
 import type { Product } from "@/types/product";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
@@ -15,32 +14,5 @@ export default async function ProductPage({ params }: Props) {
   const product: Product | null = await res.json();
   if (!product) return notFound();
 
-  const image = product.images[0]?.url;
-  const variant = product.variants[0];
-
-  return (
-    <section className="grid md:grid-cols-2 gap-8">
-      <div className="relative aspect-[4/3] rounded-2xl overflow-hidden border border-white/10">
-        {image && (
-          <Image src={image} alt={product.name} fill className="object-cover" />
-        )}
-      </div>
-
-      <div>
-        <h1 className="text-3xl font-bold">{product.name}</h1>
-        <p className="mt-2 opacity-80">Categoría: {product.category.name}</p>
-        {variant && (
-          <p className="mt-4 text-2xl font-semibold">
-            ${variant.price.toLocaleString("es-CO")}
-          </p>
-        )}
-
-        {variant && (
-          <div className="mt-6">
-            <AddToCart variantId={variant.id} />
-          </div>
-        )}
-      </div>
-    </section>
-  );
+  return <ProductDetail product={product} />;
 }

--- a/src/components/product/AddToCart.tsx
+++ b/src/components/product/AddToCart.tsx
@@ -3,24 +3,28 @@
 import { useState } from "react";
 import { useCart } from "@/store/cart";
 
-export default function AddToCart({ variantId }: { variantId: string }) {
+export default function AddToCart({ variantId, stock }: { variantId: string; stock: number }) {
   const add = useCart((s) => s.addItem);
   const [qty, setQty] = useState(1);
+  const max = Math.max(1, stock);
 
   return (
     <div className="flex gap-3">
       <input
         type="number"
         min={1}
+        max={stock}
         value={qty}
-        onChange={(e) => setQty(Number(e.target.value))}
+        onChange={(e) => setQty(Math.min(Number(e.target.value), max))}
         className="w-20 h-10 rounded-lg bg-transparent border border-white/20 text-center"
+        disabled={stock < 1}
       />
       <button
         onClick={() => add(variantId, qty)}
-        className="h-10 px-4 rounded-lg border border-white/15 hover:border-white/30"
+        disabled={stock < 1}
+        className="h-10 px-4 rounded-lg border border-white/15 hover:border-white/30 disabled:opacity-50"
       >
-        Agregar al carrito
+        {stock < 1 ? "Sin stock" : "Agregar al carrito"}
       </button>
     </div>
   );

--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -9,6 +9,7 @@ export default function ProductCard({ product }: { product: Product }) {
   const addItem = useCart((s) => s.addItem);
   const variant = product.variants[0];
   const image = product.images[0]?.url;
+  const sinStock = !variant || variant.stock < 1;
 
   return (
     <div className="rounded-2xl overflow-hidden border border-white/10">
@@ -25,6 +26,7 @@ export default function ProductCard({ product }: { product: Product }) {
             ${variant.price.toLocaleString("es-CO")}
           </p>
         )}
+        {sinStock && <p className="mt-1 text-sm text-red-400">Sin stock</p>}
 
         <div className="mt-3 grid grid-cols-2 gap-2">
           <Link
@@ -34,7 +36,7 @@ export default function ProductCard({ product }: { product: Product }) {
             Ver detalle
           </Link>
 
-          {variant && (
+          {variant && !sinStock && (
             <button
               onClick={() => addItem(variant.id, 1)}
               className="h-9 rounded-lg border border-white/15 hover:border-white/30"

--- a/src/components/product/ProductDetail.tsx
+++ b/src/components/product/ProductDetail.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import AddToCart from "@/components/product/AddToCart";
+import type { Product, Variant } from "@/types/product";
+
+function atributosStr(attrs: Record<string, string>) {
+  return Object.entries(attrs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join(", ");
+}
+
+export default function ProductDetail({ product }: { product: Product }) {
+  const [variant, setVariant] = useState<Variant | null>(product.variants[0] ?? null);
+  const image = variant?.media?.[0]?.url || product.images[0]?.url;
+
+  return (
+    <section className="grid md:grid-cols-2 gap-8">
+      <div className="relative aspect-[4/3] rounded-2xl overflow-hidden border border-white/10">
+        {image && <Image src={image} alt={product.name} fill className="object-cover" />}
+      </div>
+
+      <div>
+        <h1 className="text-3xl font-bold">{product.name}</h1>
+        <p className="mt-2 opacity-80">Categoría: {product.category.name}</p>
+        {variant && (
+          <>
+            <p className="mt-4 text-2xl font-semibold">
+              ${variant.price.toLocaleString("es-CO")}
+            </p>
+            <p className="mt-1 text-sm opacity-80">Stock: {variant.stock}</p>
+            {product.variants.length > 1 && (
+              <select
+                value={variant.id}
+                onChange={(e) =>
+                  setVariant(product.variants.find((v) => v.id === e.target.value) || null)
+                }
+                className="mt-4 w-full h-10 bg-transparent border border-white/20 rounded-lg px-2"
+              >
+                {product.variants.map((v) => (
+                  <option key={v.id} value={v.id} className="text-black">
+                    {atributosStr(v.attributes)}
+                  </option>
+                ))}
+              </select>
+            )}
+            <div className="mt-6">
+              <AddToCart variantId={variant.id} stock={variant.stock} />
+            </div>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/types/cart.ts
+++ b/src/types/cart.ts
@@ -7,6 +7,9 @@ export type CartProduct = {
 export type CartVariant = {
   id: string;
   price: number;
+  compareAtPrice?: number | null;
+  stock: number;
+  attributes: Record<string, string>;
   product: CartProduct;
 };
 

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -1,15 +1,22 @@
-export type ProductImage = {
+export type Media = {
   id: string;
   url: string;
   alt?: string | null;
+  width?: number | null;
+  height?: number | null;
+  isCover?: boolean | null;
 };
 
-export type ProductVariant = {
+export type Variant = {
   id: string;
   price: number;
+  compareAtPrice?: number | null;
+  stock: number;
+  attributes: Record<string, string>;
+  media?: Media[];
 };
 
-export type ProductCategory = {
+export type Category = {
   id: string;
   name: string;
   slug: string;
@@ -20,7 +27,8 @@ export type Product = {
   name: string;
   slug: string;
   brand?: string | null;
-  category: ProductCategory;
-  images: ProductImage[];
-  variants: ProductVariant[];
+  description?: string | null;
+  category: Category;
+  images: Media[];
+  variants: Variant[];
 };


### PR DESCRIPTION
## Resumen
- Tipos de producto, variante, media y carrito alineados con el backend
- Selector de variantes con stock y precio en detalle de producto
- Vista de compartir pedido muestra enlace de WhatsApp cuando está disponible

## Pruebas
- `npm test` (falla: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689baf8b93ac8326b65a69317b4d4259