### PR TITLE
feat: add product validation and audit logs

### DIFF
--- a/hyh-backend/prisma/migrations/20250820000000_add_product_logs/migration.sql
+++ b/hyh-backend/prisma/migrations/20250820000000_add_product_logs/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "ProductLog" (
+    "id" TEXT NOT NULL,
+    "productId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ProductLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ProductLog_productId_idx" ON "ProductLog"("productId");
+
+-- CreateIndex
+CREATE INDEX "ProductLog_userId_idx" ON "ProductLog"("userId");
+
+-- AddForeignKey
+ALTER TABLE "ProductLog" ADD CONSTRAINT "ProductLog_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProductLog" ADD CONSTRAINT "ProductLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/hyh-backend/prisma/schema.prisma
+++ b/hyh-backend/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   addresses Address[]
   orders    Order[]
   reviews   Review[]
+  productLogs ProductLog[]
 }
 
 model Address {
@@ -96,6 +97,7 @@ model Product {
   reviews        Review[]
   tags           TagOnProduct[]
   variants       Variant[]
+  logs           ProductLog[]
 
   @@index([categoryId])
   @@index([brand])
@@ -125,6 +127,19 @@ model Variant {
   product        Product             @relation(fields: [productId], references: [id])
 
   @@index([price])
+}
+
+model ProductLog {
+  id        String   @id @default(cuid())
+  productId String
+  userId    String
+  action    String
+  createdAt DateTime @default(now())
+  product   Product  @relation(fields: [productId], references: [id])
+  user      User     @relation(fields: [userId], references: [id])
+
+  @@index([productId])
+  @@index([userId])
 }
 
 model InventoryMovement {

--- a/hyh-backend/src/catalog/products/admin.controller.ts
+++ b/hyh-backend/src/catalog/products/admin.controller.ts
@@ -4,6 +4,7 @@ import {
     Param,
     Patch,
     Post,
+    Req,
     UploadedFiles,
     UseGuards,
     UseInterceptors,
@@ -29,10 +30,11 @@ export class AdminProductsController {
   @Post()
   @UseInterceptors(FilesInterceptor('images'))
   async create(
+    @Req() req: any,
     @Body() dto: CreateProductDto,
     @UploadedFiles() images: Express.Multer.File[],
   ) {
-    const product = await this.products.create(dto);
+    const product = await this.products.create(dto, req.user.sub);
     if (images?.length) {
       await this.media.uploadMany(images, { productId: product.id });
     }
@@ -43,10 +45,11 @@ export class AdminProductsController {
   @UseInterceptors(FilesInterceptor('images'))
   async update(
     @Param('id') id: string,
+    @Req() req: any,
     @Body() dto: UpdateProductDto,
     @UploadedFiles() images: Express.Multer.File[],
   ) {
-    const product = await this.products.update(id, dto);
+    const product = await this.products.update(id, dto, req.user.sub);
     if (images?.length) {
       await this.media.uploadMany(images, { productId: id });
     }

--- a/hyh-backend/src/catalog/products/dto/create-product.dto.ts
+++ b/hyh-backend/src/catalog/products/dto/create-product.dto.ts
@@ -1,4 +1,12 @@
-import { IsArray, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import {
+  IsArray,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { CreateVariantDto } from './create-variant.dto';
 
 export class CreateProductDto {
   @IsString()
@@ -29,4 +37,10 @@ export class CreateProductDto {
   @IsArray()
   @IsString({ each: true })
   hairType?: string[];
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateVariantDto)
+  variants?: CreateVariantDto[];
 }

--- a/hyh-backend/src/catalog/products/dto/create-variant.dto.ts
+++ b/hyh-backend/src/catalog/products/dto/create-variant.dto.ts
@@ -1,0 +1,20 @@
+import { IsInt, IsObject, IsOptional, Min } from 'class-validator';
+
+export class CreateVariantDto {
+  @IsObject()
+  attributes: Record<string, any>;
+
+  @IsInt({ message: 'price must be a number' })
+  @Min(0)
+  price: number;
+
+  @IsOptional()
+  @IsInt({ message: 'compareAtPrice must be a number' })
+  @Min(0)
+  compareAtPrice?: number;
+
+  @IsOptional()
+  @IsInt({ message: 'stock must be a number' })
+  @Min(0)
+  stock?: number;
+}

--- a/hyh-backend/src/catalog/products/dto/update-product.dto.ts
+++ b/hyh-backend/src/catalog/products/dto/update-product.dto.ts
@@ -1,4 +1,17 @@
 import { PartialType } from '@nestjs/mapped-types';
+import {
+  IsArray,
+  IsOptional,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
 import { CreateProductDto } from './create-product.dto';
+import { UpdateVariantDto } from './update-variant.dto';
 
-export class UpdateProductDto extends PartialType(CreateProductDto) {}
+export class UpdateProductDto extends PartialType(CreateProductDto) {
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => UpdateVariantDto)
+  variants?: UpdateVariantDto[];
+}

--- a/hyh-backend/src/catalog/products/dto/update-variant.dto.ts
+++ b/hyh-backend/src/catalog/products/dto/update-variant.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateVariantDto } from './create-variant.dto';
+
+export class UpdateVariantDto extends PartialType(CreateVariantDto) {}

--- a/hyh-backend/src/catalog/products/products.service.ts
+++ b/hyh-backend/src/catalog/products/products.service.ts
@@ -137,12 +137,20 @@ export class ProductsService {
     return p;
   }
 
-  async create(dto: CreateProductDto) {
-      return this.prisma.product.create({ data: dto });
-    }
+  async create(dto: CreateProductDto, userId: string) {
+    const product = await this.prisma.product.create({ data: dto });
+    await this.prisma.productLog.create({
+      data: { productId: product.id, userId, action: 'CREATE' },
+    });
+    return product;
+  }
 
-    async update(id: string, dto: UpdateProductDto) {
-      return this.prisma.product.update({ where: { id }, data: dto });
-    }
+  async update(id: string, dto: UpdateProductDto, userId: string) {
+    const product = await this.prisma.product.update({ where: { id }, data: dto });
+    await this.prisma.productLog.create({
+      data: { productId: id, userId, action: 'UPDATE' },
+    });
+    return product;
+  }
 
 }


### PR DESCRIPTION
## Summary
- validate nested product variant prices and data
- record admin user actions when creating or updating products
- add database table for product audit logs

## Testing
- `npm test`
- `npm run lint`
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_b_68a3a67e91f08321bae1bd5cf51662b9