### PR TITLE
Refactor product detail and services pages

### DIFF
--- a/src/app/servicios/Servicios.tsx
+++ b/src/app/servicios/Servicios.tsx
@@ -1,48 +1,111 @@
 "use client";
 
+import Image from "next/image";
 import { useState } from "react";
 
 export default function Servicios() {
   const servicios = [
-    { nombre: "Corte de cabello", descripcion: "Estilos modernos y clásicos." },
-    { nombre: "Arreglo de barba", descripcion: "Perfilado y afeitado tradicional." },
-    { nombre: "Tintura", descripcion: "Color para cabello y barba." },
+    { nombre: "Corte clásico", precio: 25000, duracion: "45 min", img: "/img/corte.jpg" },
+    { nombre: "Arreglo de barba", precio: 20000, duracion: "30 min", img: "/img/barba.jpg" },
+    { nombre: "Corte + Barba", precio: 40000, duracion: "70 min", img: "/img/pack.jpg" },
   ];
-  const [servicioSeleccionado, setServicioSeleccionado] = useState<
-    (typeof servicios)[number] | null
-  >(null);
+  type Servicio = (typeof servicios)[number];
+  const [servicioSeleccionado, setServicioSeleccionado] = useState<Servicio | null>(
+    null,
+  );
   const [direccion, setDireccion] = useState("");
+  const [fecha, setFecha] = useState("");
   const [hora, setHora] = useState("");
+  const [notas, setNotas] = useState("");
 
   const enviarWhatsApp = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!servicioSeleccionado) return;
     const mensaje = encodeURIComponent(
-      `Hola, deseo agendar ${servicioSeleccionado.nombre} en ${direccion} a las ${hora}.`
+      `Hola, deseo agendar ${servicioSeleccionado.nombre} el ${fecha} a las ${hora} en ${direccion}. ${
+        notas ? `Notas: ${notas}` : ""
+      }`
     );
     window.open(`https://wa.me/573138907119?text=${mensaje}`);
     setServicioSeleccionado(null);
     setDireccion("");
+    setFecha("");
     setHora("");
+    setNotas("");
   };
 
   return (
     <section>
-      <h1 className="text-3xl font-bold text-center">Servicios</h1>
-      <ul className="mt-8 grid gap-6 md:grid-cols-3">
+      <section className="text-center space-y-3">
+        <h1 className="text-4xl font-bold">Barbería a Domicilio</h1>
+        <p className="opacity-80">
+          Profesionales a tu puerta, puntuales y con higiene certificada.
+        </p>
+        <div className="flex justify-center gap-3">
+          <a
+            href="#servicios"
+            className="border border-gold rounded-xl px-4 py-2 hover:bg-gold hover:text-black"
+          >
+            Ver servicios
+          </a>
+          <a
+            href="https://wa.me/573138907119"
+            className="bg-gold text-black rounded-xl px-4 py-2"
+          >
+            Agendar por WhatsApp
+          </a>
+        </div>
+      </section>
+
+      <div id="servicios" className="mt-10 grid gap-6 md:grid-cols-3">
         {servicios.map((s) => (
-          <li key={s.nombre} className="p-4 border border-white/10 rounded-lg">
-            <h2 className="text-xl font-semibold">{s.nombre}</h2>
-            <p className="mt-2 opacity-80">{s.descripcion}</p>
-            <button
-              className="mt-4 px-4 py-2 bg-blue-600 text-white rounded"
-              onClick={() => setServicioSeleccionado(s)}
-            >
-              Agendar
-            </button>
-          </li>
+          <article
+            key={s.nombre}
+            className="rounded-2xl overflow-hidden border border-white/10 hover:border-gold/40 transition"
+          >
+            <div className="relative h-44">
+              <Image src={s.img} alt={s.nombre} fill className="object-cover" />
+            </div>
+            <div className="p-4">
+              <h3 className="text-xl font-semibold">{s.nombre}</h3>
+              <p className="opacity-80 text-sm">{s.duracion}</p>
+              <p className="text-lg font-semibold">
+                ${s.precio.toLocaleString("es-CO")}
+              </p>
+              <button
+                onClick={() => setServicioSeleccionado(s)}
+                className="mt-2 w-full rounded-xl border border-gold px-4 py-2 hover:bg-gold hover:text-black"
+              >
+                Agendar
+              </button>
+            </div>
+          </article>
         ))}
-      </ul>
+      </div>
+
+      <details className="p-4 border-t border-white/10 mt-10">
+        <summary className="cursor-pointer font-medium">
+          Higiene y bioseguridad
+        </summary>
+        <p className="mt-2 opacity-80 text-sm">
+          Utensilios esterilizados y desinfección constante.
+        </p>
+      </details>
+      <details className="p-4 border-t border-white/10">
+        <summary className="cursor-pointer font-medium">
+          Cobertura y horarios
+        </summary>
+        <p className="mt-2 opacity-80 text-sm">
+          Armenia y Calarcá de 8am a 8pm.
+        </p>
+      </details>
+      <details className="p-4 border-t border-white/10">
+        <summary className="cursor-pointer font-medium">
+          Métodos de pago
+        </summary>
+        <p className="mt-2 opacity-80 text-sm">Efectivo o transferencia.</p>
+      </details>
+
       {servicioSeleccionado && (
         <div className="fixed inset-0 flex items-center justify-center bg-black/50">
           <div className="w-full max-w-md rounded-lg bg-neutral-900 p-6 text-white">
@@ -73,12 +136,29 @@ export default function Servicios() {
                 className="w-full rounded border border-white/10 bg-neutral-800 p-2"
               />
               <input
+                type="date"
+                required
+                value={fecha}
+                onChange={(e) => setFecha(e.target.value)}
+                className="w-full rounded border border-white/10 bg-neutral-800 p-2"
+              />
+              <input
                 type="time"
                 required
                 value={hora}
                 onChange={(e) => setHora(e.target.value)}
                 className="w-full rounded border border-white/10 bg-neutral-800 p-2"
               />
+              <textarea
+                placeholder="Notas"
+                value={notas}
+                onChange={(e) => setNotas(e.target.value)}
+                className="w-full rounded border border-white/10 bg-neutral-800 p-2"
+              />
+              <p className="text-xs opacity-80">
+                Atención en Armenia y Calarcá. Cancelaciones con 2h de
+                anticipación.
+              </p>
               <div className="flex justify-end gap-2">
                 <button
                   type="button"
@@ -89,7 +169,7 @@ export default function Servicios() {
                 </button>
                 <button
                   type="submit"
-                  className="rounded bg-blue-600 px-4 py-2 text-white"
+                  className="rounded bg-gold text-black px-4 py-2"
                 >
                   Agendar
                 </button>
@@ -98,6 +178,13 @@ export default function Servicios() {
           </div>
         </div>
       )}
+
+      <a
+        href="https://wa.me/573138907119"
+        className="fixed bottom-4 right-4 z-50 bg-gold text-black rounded-xl px-4 py-2 md:hidden"
+      >
+        Agendar ahora
+      </a>
     </section>
   );
 }

--- a/src/components/product/ProductDetail.tsx
+++ b/src/components/product/ProductDetail.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Image from "next/image";
 import AddToCart from "@/components/product/AddToCart";
+import ProductCard from "@/components/product/ProductCard";
 import type { Product, Variant } from "@/types/product";
 
 function atributosStr(attrs: Variant["attributes"]) {
@@ -12,32 +13,59 @@ function atributosStr(attrs: Variant["attributes"]) {
 }
 
 export default function ProductDetail({ product }: { product: Product }) {
+  const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
   const [variant, setVariant] =
-      useState<Variant | null>(product.variants[0] ?? null);
-    const imagenes = variant?.media?.length ? variant.media : product.images;
-    const [indiceImg, setIndiceImg] = useState(0);
+    useState<Variant | null>(product.variants[0] ?? null);
+  const imagenes = variant?.media?.length ? variant.media : product.images;
+  const [indiceImg, setIndiceImg] = useState(0);
+  const [related, setRelated] = useState<Product[]>([]);
 
-    useEffect(() => {
-      setIndiceImg(0);
-    }, [variant]);
+  useEffect(() => {
+    setIndiceImg(0);
+  }, [variant]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "ArrowRight")
+        setIndiceImg((i) => (i + 1) % imagenes.length);
+      if (e.key === "ArrowLeft")
+        setIndiceImg((i) => (i - 1 + imagenes.length) % imagenes.length);
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [imagenes.length]);
+
+  useEffect(() => {
+    const fetchRelated = async () => {
+      try {
+        const res = await fetch(
+          `${API_URL}/products?category=${product.category.slug}`,
+        );
+        if (!res.ok) return;
+        const data: Product[] = await res.json();
+        setRelated(data.filter((p) => p.id !== product.id));
+      } catch {
+        // ignore
+      }
+    };
+    fetchRelated();
+  }, [API_URL, product]);
 
   const imagen = imagenes[indiceImg]?.url;
   return (
-    <section className="grid md:grid-cols-2 gap-8">
-      <div>
-        <div className="relative aspect-[4/3] rounded-2xl overflow-hidden border border-white/10">
-          {imagen && (
-            <Image src={imagen} alt={product.name} fill className="object-cover" />
-          )}
-        </div>
-        {imagenes.length > 1 && (
-          <div className="flex gap-2 mt-2">
+    <section>
+      <nav className="mb-4 text-sm opacity-80">
+        Inicio / Productos / {product.category.name} / {product.name}
+      </nav>
+      <div className="grid lg:grid-cols-2 gap-10">
+        <div className="grid grid-cols-[96px_1fr] gap-4">
+          <div className="flex lg:flex-col gap-3">
             {imagenes.map((img, idx) => (
               <button
                 key={img.id ?? idx}
                 onClick={() => setIndiceImg(idx)}
-                className={`relative w-16 h-16 rounded-md overflow-hidden border ${
-                  idx === indiceImg ? "border-white/50" : "border-white/10"
+                className={`h-20 w-20 rounded-xl overflow-hidden ring-1 ${
+                  idx === indiceImg ? "ring-gold/60" : "ring-white/10"
                 }`}
               >
                 <Image
@@ -49,44 +77,90 @@ export default function ProductDetail({ product }: { product: Product }) {
               </button>
             ))}
           </div>
-        )}
-      </div>
-
-      <div>
-        <h1 className="text-3xl font-bold">{product.name}</h1>
-        <p className="mt-2 opacity-80">Categoría: {product.category.name}</p>
-          {product.description && (
-            <p className="mt-4 opacity-80">{product.description}</p>
-          )}
-        {variant && (
-          <>
-            <p className="mt-4 text-2xl font-semibold">
-              ${variant.price.toLocaleString("es-CO")}
-            </p>
-            <p className="mt-1 text-sm opacity-80">Stock: {variant.stock}</p>
-            {product.variants.length > 1 && (
-              <select
-                value={variant.id}
-                onChange={(e) =>
-                  setVariant(
-                    product.variants.find((v) => v.id === e.target.value) || null,
-                  )
-                }
-                className="mt-4 w-full h-10 bg-transparent border border-white/20 rounded-lg px-2"
-              >
-                {product.variants.map((v) => (
-                  <option key={v.id} value={v.id} className="text-black">
-                    {atributosStr(v.attributes)}
-                  </option>
-                ))}
-              </select>
+          <div className="relative aspect-[4/5] rounded-2xl overflow-hidden border border-white/10 group">
+            {imagen && (
+              <Image
+                src={imagen}
+                alt={product.name}
+                fill
+                className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+              />
             )}
-            <div className="mt-6">
-              <AddToCart variantId={variant.id} stock={variant.stock} />
-            </div>
-          </>
-        )}
+          </div>
+        </div>
+
+        <div className="lg:sticky lg:top-24 space-y-4">
+          <h1 className="text-3xl font-bold">{product.name}</h1>
+          <p className="opacity-80">Categoría: {product.category.name}</p>
+          {product.description && (
+            <p className="opacity-80">{product.description}</p>
+          )}
+          {variant && (
+            <>
+              <p className="text-2xl font-semibold">
+                ${variant.price.toLocaleString("es-CO")}
+              </p>
+              <p className="text-sm opacity-80">Stock: {variant.stock}</p>
+              {product.variants.length > 1 && (
+                <div className="flex flex-wrap gap-2 mt-4">
+                  {product.variants.map((v) => (
+                    <button
+                      key={v.id}
+                      onClick={() => setVariant(v)}
+                      className={`px-3 py-2 rounded-xl border text-sm ${
+                        variant?.id === v.id
+                          ? "border-gold bg-gold/10"
+                          : "border-white/15 hover:border-gold/60"
+                      }`}
+                    >
+                      {atributosStr(v.attributes)}
+                    </button>
+                  ))}
+                </div>
+              )}
+              <div className="mt-6">
+                <AddToCart variantId={variant.id} stock={variant.stock} />
+              </div>
+            </>
+          )}
+          <details className="p-4 border-t border-white/10">
+            <summary className="cursor-pointer font-medium">
+              Envíos y cobertura
+            </summary>
+            <p className="mt-2 opacity-80 text-sm">
+              Armenia/Calarcá contraentrega. Resto del país por transportadora.
+            </p>
+          </details>
+          <details className="p-4 border-t border-white/10">
+            <summary className="cursor-pointer font-medium">
+              Cambios y devoluciones
+            </summary>
+            <p className="mt-2 opacity-80 text-sm">
+              Aceptamos cambios dentro de los 5 días con factura.
+            </p>
+          </details>
+          <details className="p-4 border-t border-white/10">
+            <summary className="cursor-pointer font-medium">Pagos</summary>
+            <p className="mt-2 opacity-80 text-sm">
+              Efectivo, transferencias y datáfono.
+            </p>
+          </details>
+        </div>
       </div>
+      {related.length > 0 && (
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold mb-4">
+            También te puede gustar
+          </h2>
+          <div className="flex gap-4 overflow-x-auto pb-2">
+            {related.map((p) => (
+              <div key={p.id} className="min-w-[200px]">
+                <ProductCard product={p} />
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Add gallery with thumbnails, keyboard navigation, and sticky info on product detail
- Replace variant select with chips and add trust accordions and related products slider
- Redesign services page with hero, service cards, enhanced scheduling modal, trust sections, and mobile CTA

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68acbf16e1208324bc72c7313d0c279b