### PR TITLE
Add authenticated API routes for checkout and addresses

### DIFF
--- a/src/app/api/me/addresses/[id]/route.ts
+++ b/src/app/api/me/addresses/[id]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const token = req.cookies.get("token")?.value;
+  const body = await req.text();
+  const res = await fetch(`${API_URL}/me/addresses/${params.id}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body,
+  });
+  const data = await res.json().catch(() => ({}));
+  return NextResponse.json(data, { status: res.status });
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const token = req.cookies.get("token")?.value;
+  const res = await fetch(`${API_URL}/me/addresses/${params.id}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const data = await res.json().catch(() => ({}));
+  return NextResponse.json(data, { status: res.status });
+}
+

--- a/src/app/api/me/addresses/route.ts
+++ b/src/app/api/me/addresses/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
+
+export async function GET(req: NextRequest) {
+  const token = req.cookies.get("token")?.value;
+  const res = await fetch(`${API_URL}/me/addresses`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: "no-store",
+  });
+  const data = await res.json().catch(() => ({}));
+  return NextResponse.json(data, { status: res.status });
+}
+
+export async function POST(req: NextRequest) {
+  const token = req.cookies.get("token")?.value;
+  const body = await req.text();
+  const res = await fetch(`${API_URL}/me/addresses`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body,
+  });
+  const data = await res.json().catch(() => ({}));
+  return NextResponse.json(data, { status: res.status });
+}
+

--- a/src/app/api/me/addresses/set-default/route.ts
+++ b/src/app/api/me/addresses/set-default/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
+
+export async function POST(req: NextRequest) {
+  const token = req.cookies.get("token")?.value;
+  const body = await req.text();
+  const res = await fetch(`${API_URL}/me/addresses/set-default`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body,
+  });
+  const data = await res.json().catch(() => ({}));
+  return NextResponse.json(data, { status: res.status });
+}
+

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
+
+export async function POST(req: NextRequest) {
+  const token = req.cookies.get("token")?.value;
+  const body = await req.text();
+  const res = await fetch(`${API_URL}/orders`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body,
+  });
+  const data = await res.json().catch(() => ({}));
+  return NextResponse.json(data, { status: res.status });
+}
+

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { apiFetch, useApi } from "@/lib/api";
+import { apiFetch, apiFetchAuth, useApiAuth } from "@/lib/api";
 import { useCart } from "@/store/cart";
 import type { Address } from "@/types/address";
 import { useEffect, useState } from "react";
@@ -18,7 +18,7 @@ type Preview = {
 export default function CheckoutPage() {
   const { items, clear, id: cartId } = useCart();
 
-  const { data: direcciones } = useApi<Address[]>("/me/addresses");
+  const { data: direcciones } = useApiAuth<Address[]>("/me/addresses");
   const [direccionId, setDireccionId] = useState("");
   const [ciudad, setCiudad] = useState("");
   const [linea1, setLinea1] = useState("");
@@ -89,7 +89,7 @@ export default function CheckoutPage() {
       } else {
         body.addressRaw = { country: "Colombia", city: ciudad, line1: linea1 };
       }
-      await apiFetch<{ orderId: string }>("/orders", {
+      await apiFetchAuth<{ orderId: string }>("/orders", {
         method: "POST",
         body: JSON.stringify(body),
       });

--- a/src/app/mi-cuenta/direcciones/page.tsx
+++ b/src/app/mi-cuenta/direcciones/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { apiFetch, useApi } from "@/lib/api";
+import { apiFetchAuth, useApiAuth } from "@/lib/api";
 import type { Address } from "@/types/address";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useState } from "react";
@@ -19,7 +19,9 @@ const schema = z.object({
 type FormData = z.infer<typeof schema>;
 
 export default function DireccionesPage() {
-  const { data: direcciones, isLoading, mutate } = useApi<Address[]>("/me/addresses");
+  const { data: direcciones, isLoading, mutate } = useApiAuth<Address[]>(
+    "/me/addresses",
+  );
   const [editando, setEditando] = useState<Address | null>(null);
 
   const {
@@ -32,12 +34,12 @@ export default function DireccionesPage() {
   const onSubmit = async (data: FormData) => {
     try {
       if (editando) {
-        await apiFetch(`/me/addresses/${editando.id}`, {
+        await apiFetchAuth(`/me/addresses/${editando.id}`, {
           method: "PATCH",
           body: JSON.stringify(data),
         });
       } else {
-        await apiFetch("/me/addresses", {
+        await apiFetchAuth("/me/addresses", {
           method: "POST",
           body: JSON.stringify(data),
         });
@@ -62,14 +64,14 @@ export default function DireccionesPage() {
 
   const eliminar = async (id: string) => {
     try {
-      await apiFetch(`/me/addresses/${id}`, { method: "DELETE" });
+      await apiFetchAuth(`/me/addresses/${id}`, { method: "DELETE" });
       mutate();
     } catch {}
   };
 
   const porDefecto = async (id: string) => {
     try {
-      await apiFetch("/me/addresses/set-default", {
+      await apiFetchAuth("/me/addresses/set-default", {
         method: "POST",
         body: JSON.stringify({ id }),
       });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -49,3 +49,9 @@ export function useApi<T>(path: string) {
   const { data, error, isLoading, mutate } = useSWR<T>(path, fetcher);
   return { data, error, isLoading, mutate };
 }
+
+export function useApiAuth<T>(path: string) {
+  const fetcher = () => apiFetchAuth<T>(path);
+  const { data, error, isLoading, mutate } = useSWR<T>(path, fetcher);
+  return { data, error, isLoading, mutate };
+}


### PR DESCRIPTION
## Summary
- add internal API proxies for addresses and orders that forward auth token
- expose `useApiAuth` helper and use it in checkout and address pages
- update checkout to create orders through authenticated endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68af3fe7d73c8324b98e1dd1b3f496d5